### PR TITLE
fix(restore): make RESTORE_STRUCTURED_BACKUP usable for cross-adapter migration

### DIFF
--- a/main/commands_impl.h
+++ b/main/commands_impl.h
@@ -257,7 +257,18 @@ struct zb_ncp::cmd_handle<GET_ZIGBEE_CHANNEL_MASK> : immediate_cmd_process<GET_Z
 	static void process_status_res(ncp_generic_status_t& status,GET_ZIGBEE_CHANNEL_MASK_resp_t* res) {
     	res->len = 1;
     	res->page = 0;
-    	res->mask = zb_get_channel_mask();
+    	// After a structured restore + reboot, zb_get_channel_mask() can
+    	// return out-of-spec values (observed: 0x00FFFFFF — bits below
+    	// channel 11 set). zigpy rejects such bitmaps (its Channels type
+    	// raises on unexpected members, crashing backup serialization and
+    	// the ZHA repair flow), so clamp to the valid 2.4 GHz channel set
+    	// and fall back to the current channel when nothing valid remains.
+    	uint32_t mask = zb_get_channel_mask() & 0x07FFF800u;
+    	if (mask == 0u) {
+    		uint8_t ch = zb_get_current_channel();
+    		mask = (ch >= 11 && ch <= 26) ? (1u << ch) : 0x07FFF800u;
+    	}
+    	res->mask = mask;
     }
 };
 // // Set Zigbee channels page and mask

--- a/main/zb_ncp.cpp
+++ b/main/zb_ncp.cpp
@@ -20,6 +20,14 @@ static const char* TAG = "NCP";
 
 #include "commands_impl.h"
 
+// Channel mask from a restored TAG_CHANNEL. init_int() refreshes
+// m_channels_mask from zb_get_channel_mask() AFTER apply_pending_restore()
+// runs, and at that point the getter still reports the stack default — so
+// the restored mask must be carried to the forced formation separately or
+// formation scans the default mask and forms on the lowest channel (11)
+// instead of the restored one.
+static uint32_t s_restore_channel_mask = 0;
+
 // Set to true by apply_pending_restore() when it actually applies a TLV.
 // continue_zboss reads it to force NETWORK_FORMATION (which performs the
 // channel-scan step) instead of the default STEERING — without the explicit
@@ -132,7 +140,14 @@ static void apply_pending_restore() {
                     zb_set_channel_mask(mask);
                     zb_set_bdb_primary_channel_set(mask);
                     zb_set_bdb_secondary_channel_set(mask);
-                    ESP_LOGI(TAG, "  Channel = %u (mask 0x%08lx)", ch, (unsigned long)mask);
+                    s_restore_channel_mask = mask;
+                    // The restore-forced FORMATION on an already-provisioned
+                    // NIB completes without a channel scan, so the transceiver
+                    // stays on the MAC default channel. Preset the PIB cache
+                    // the way an NVRAM dataset load would — MAC picks it up
+                    // when the stack starts.
+                    ZB_PIBCACHE_CURRENT_CHANNEL() = ch;
+                    ESP_LOGI(TAG, "  Channel = %u (mask 0x%08lx, PIB preset)", ch, (unsigned long)mask);
                 }
             } break;
             case backup_structured::TAG_NWK_UPDATE_ID: {
@@ -579,7 +594,8 @@ void zb_ncp::continue_zboss(uint8_t arg) {
         // the scan to the restored channel and the NIB values we just set
         // survive because we are in factory-reset state per #445.
         ESP_LOGI(TAG, "continue_zboss: restore applied, forcing NETWORK_FORMATION");
-        set_channel_mask(instance().m_channels_mask);
+        set_channel_mask(s_restore_channel_mask ? s_restore_channel_mask
+                                                : instance().m_channels_mask);
         bdb_start_top_level_commissioning(ZB_BDB_NETWORK_FORMATION);
     } else {
         // BOOT-1: plain boot (no pending formation, no restore). Run ONLY the
@@ -716,6 +732,16 @@ extern "C" void zboss_signal_handler(zb_uint8_t param)
             // decision via NWK_PERMIT_JOINING. Also covers the
             // restore-forced formation path (s_restore_applied).
             ESP_LOGI(TAG, "Formed network successfully");
+            if (s_restore_applied) {
+                // The restored NWK outgoing frame counter lives only in RAM at
+                // this point: the formation persisted ZB_IB_COUNTERS before
+                // esp_zb_nwk_set_frame_counter's value landed, so a reboot
+                // would resume from ~0 and every device would drop our
+                // NWK-secured traffic as replays. Persist it now, while the
+                // live counter demonstrably holds the restored value.
+                zb_nvram_write_dataset(ZB_IB_COUNTERS);
+                ESP_LOGI(TAG, "restore: persisted ZB_IB_COUNTERS (frame counter)");
+            }
         }
 
         break;


### PR DESCRIPTION
## Summary

`RESTORE_STRUCTURED_BACKUP` (0x009C) is the only way to bring a network from a *different vendor's* coordinator onto esp-coordinator (the raw-NVRAM path is byte-true ZBOSS and therefore same-firmware-only). Exercising it end to end for a real cross-adapter migration — Home Assistant SkyConnect (Silabs EZSP) → XIAO ESP32-C6 — surfaced four bugs. With these fixes, a 20-device production network (Hue, TI-based plugs, an ESPHome router) migrated with **zero re-pairing**: I built the ZBSB v1 TLV from a zigpy unified backup, pushed it over 0x009C, and every router rejoined the impersonated coordinator.

## The bugs and fixes

**1. The restored channel mask is clobbered before the forced formation.**
`apply_pending_restore()` sets the mask from `TAG_CHANNEL`, but `init_int()` then refreshes `m_channels_mask` from `zb_get_channel_mask()` — which still reports the stack default at that point — so `continue_zboss`'s restore branch re-armed the default mask. Fixed by carrying the restored mask in `s_restore_channel_mask` and preferring it in the restore-forced formation.

**2. The radio forms on channel 11 no matter what the mask says.**
The restore-forced `ZB_BDB_NETWORK_FORMATION` on an already-provisioned NIB completes in ~20 ms *without a channel scan*, so the transceiver simply stays on the MAC default channel. Observed over the air: the restored network (correct PAN/ExtPAN/key) beaconing on channel 11 while the mask said 20 — confirmed by beacon-scanning with a second radio and diffing scans with the ESP held in its bootloader. Fixed by presetting `ZB_PIBCACHE_CURRENT_CHANNEL()` in `apply_pending_restore()`, the same way an NVRAM dataset load would; MAC picks it up at stack start.

**3. The restored NWK frame counter doesn't survive a reboot.**
`esp_zb_nwk_set_frame_counter()`'s value was live (verified: GET_STRUCTURED_BACKUP read back planted+1) but the formation persisted `ZB_IB_COUNTERS` before it landed, so the next boot resumed from ~0×lookahead (observed 1024/2048). For a migrated network that is fatal: every device silently drops coordinator traffic as replays. Fixed by calling `zb_nvram_write_dataset(ZB_IB_COUNTERS)` in the `ZB_BDB_SIGNAL_FORMATION` success handler when `s_restore_applied`, while the live counter demonstrably holds the restored value. Verified: after reboot the counter resumed *above* the planted value (9,189,376 vs planted 9,189,025).

**4. `GET_ZIGBEE_CHANNEL_MASK` can report an out-of-spec bitmap.**
Post-restore the raw `zb_get_channel_mask()` read back `0x00FFFFFF` (bits below channel 11 set). zigpy's `Channels` type raises `ValueError: Channels bitmap has unexpected members` on such values, which crashes zigpy-zboss backup serialization and — worse — Home Assistant ZHA's `network_settings_inconsistent` repair flow, turning a recoverable warning into a hard setup failure. Fixed by clamping the reported mask to the valid 2.4 GHz set (`0x07FFF800`) with a current-channel fallback.

## Validation

- Built against ESP-IDF v5.5.5, esp32c6 target, on top of current `master`.
- Hardware: Seeed XIAO ESP32-C6 (external-antenna build), migrating a live SkyConnect (EZSP stack 7.4.4.5) network: PAN/ExtPAN/channel/key/coordinator-IEEE/frame-counter via ZBSB TLV → 0x009C.
- Verified live and across reboots via GET_STRUCTURED_BACKUP/GET_ZIGBEE_CHANNEL, over the air via active beacon scans from a second radio (network beacons on the restored channel only), by encrypted ZDO round trips with migrated devices (node descriptor of a Hue router returned manufacturer 0x100B), and finally end to end under Home Assistant ZHA (zha-zboss-esp): 20 devices / 181 entities live with no re-pairing.

## Notes for the docs (not in this diff)

- ZHA users adopting a migrated network need `zigpy_config: {backup_enabled: false, validate_network_settings: false}` — the placeholder network key (`ESP-ZBOSS-NO-KEY`) can never match a pre-migration backup stored in `zigbee.db`. Happy to send a README paragraph as a follow-up if useful.
- While debugging with a diag build (`CONFIG_ESP_CONSOLE_SECONDARY_USB_SERIAL_JTAG` + INFO logs), boot-guard SAFE MODE wedges before `transport::start` (task_wdt on esp_timer, console/NCP contention on USB) — unreachable by NCP_RESET, only a power cycle recovers. Production config is unaffected; can file separately if you want it tracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
